### PR TITLE
Add 'Work left' count to the UserStatusDetailsWidget in the sidebar

### DIFF
--- a/src/main/java/scrum/client/collaboration/UserStatusDetailsWidget.java
+++ b/src/main/java/scrum/client/collaboration/UserStatusDetailsWidget.java
@@ -72,6 +72,14 @@ public class UserStatusDetailsWidget extends AScrumWidget {
 				setContent(ScrumGwt.createReferencesWidget(issues));
 			}
 		});
+		tb.addFieldRow("Work left", new AFieldValueWidget() {
+
+			@Override
+			protected void onUpdate() {
+				List<Task> tasks = project.getCurrentSprint().getClaimedTasks(user);
+				setText(Integer.toString(Task.sumRemainingWork(tasks)));
+			}
+		});
 		return tb.createTable();
 	}
 


### PR DESCRIPTION
Hi, Kunagi team,

I work on an open-source agile project which uses Kunagi internally (http://projectclearwater.org), and one of the things we struggle with is getting an overview of the total time we each have left on our tasks, so that we can see whether we're over- or under-committed, and better track how much progress we make each day.

This patch adds a "Work left" count to the UserStatusDetailsWidget (beneath 'Tasks' and 'Issues') which tracks the total number of hours remaining on all tasks that user has claimed. I think it's going to be useful for us, so it might well be useful for others.

I have a screenshot of how it looks on my blog: http://robertkday.wordpress.com/2013/06/17/my-first-foray-into-kunagi-development/

Thanks,
Rob
