### PR TITLE
Working Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM consol/tomcat-8.0
+
+MAINTAINER Friedrich Große <friedrich.grosse@gmail.com>
+ENV DEPLOY_DIR /kunagi
+
+RUN apt-get update
+
+# Install build dependencies
+RUN apt-get install -y ant git unzip bzip2 && apt-get clean
+
+# Build ilarkesto
+WORKDIR /build/ilarkesto
+RUN git clone https://github.com/Kunagi/ilarkesto.git .
+RUN ./update-libs.bsh
+RUN ant package
+
+# Build kunagi
+WORKDIR /build/kunagi
+ADD . /build/kunagi 
+RUN ant webapp
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
-FROM consol/tomcat-8.0
+FROM consol/tomcat-7.0
 
 MAINTAINER Friedrich Große <friedrich.grosse@gmail.com>
+ENV KUNAGI_VERSION 0.26
+
+EXPOSE 8080
 ENV DEPLOY_DIR /kunagi
 
-RUN apt-get update
+RUN wget http://kunagi.org/releases/${KUNAGI_VERSION}/kunagi.war --directory-prefix=kunagi
 
-# Install build dependencies
-RUN apt-get install -y ant git unzip bzip2 && apt-get clean
-
-# Build ilarkesto
-WORKDIR /build/ilarkesto
-RUN git clone https://github.com/Kunagi/ilarkesto.git .
-RUN ./update-libs.bsh
-RUN ant package
-
-# Build kunagi
-WORKDIR /build/kunagi
-ADD . /build/kunagi 
-RUN ant webapp
-
+CMD /opt/tomcat/bin/deploy-and-run.sh


### PR DESCRIPTION
I create a Dockerfile for kunagi so everybody will be able to install it using docker.
A working container has been pushed to https://registry.hub.docker.com/u/fgrosse/kunagi/

I think this could really help improving the popularity of the project since its now very easy to setup kunagi on any machine that runs docker with two commands (docker pull and docker run).

This docker image uses the I binary war file to install kunagi. At first I tried to build kunagi from source but had some problems with that. I'm going to create a ticket for that later.
You can checkout the container build from source at https://github.com/FGrosse/kunagi/tree/docker/from-source
